### PR TITLE
Added SQLite support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ states, and printing readable diffs.
 - MySQL 5.5 to 9.5+
 - MariaDB 10.0 to 12.1+
 - PostgreSQL 11.0 to 18.1+
+- SQLite 3.x
 
 
 ## Installation
@@ -63,7 +64,8 @@ The checker ships with SQL helpers from namespace `\Roslov\MigrationChecker\Db`:
 - `Dumper` automatically detects the database type and dumps its schema.
     It uses `DatabaseDetector` to determine which schema dumper to use:
     - `MySqlDumper` dumps the schema for MySQL or MariaDB,
-    - `PostgreSqlDumper` dumps the schema for PostgreSQL.
+    - `PostgreSqlDumper` dumps the schema for PostgreSQL,
+    - `SqLiteDumper` dumps the schema for SQLite.
 - `SqlQuery` fetches data from SQL database via PDO connection.
 
 
@@ -193,7 +195,7 @@ final class Environment implements EnvironmentInterface
     /**
      * Cleans up the environment after migration checks.
      */
-    public function cleanup(): void
+    public function cleanUp(): void
     {
         // No-op
     }

--- a/src/Db/Dumper.php
+++ b/src/Db/Dumper.php
@@ -53,6 +53,7 @@ final class Dumper implements DumperInterface
             DatabaseType::MySql,
             DatabaseType::MariaDd => new MySqlDumper($this->query),
             DatabaseType::PostgreSql => new PostgreSqlDumper($this->query),
+            DatabaseType::SqLite => new SqLiteDumper($this->query),
             default => throw new UnknownDatabaseTypeException(
                 sprintf('Unsupported database type: %s', $dbType->value),
             ),

--- a/src/Db/SqLiteDumper.php
+++ b/src/Db/SqLiteDumper.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roslov\MigrationChecker\Db;
+
+use Roslov\MigrationChecker\Contract\DumperInterface;
+use Roslov\MigrationChecker\Contract\QueryInterface;
+use Roslov\MigrationChecker\Contract\StateInterface;
+
+/**
+ * Fetches the SQLite dump.
+ */
+final class SqLiteDumper implements DumperInterface
+{
+    /**
+     * Constructor.
+     *
+     * @param QueryInterface $query Query fetcher
+     */
+    public function __construct(private readonly QueryInterface $query)
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDump(): StateInterface
+    {
+        $sql = <<<'SQL_WRAP'
+            SELECT type, name, `sql`
+            FROM sqlite_master
+            WHERE `sql` IS NOT NULL
+            AND name NOT LIKE 'sqlite_%'
+            ORDER BY
+                CASE type
+                    WHEN 'table' THEN 0
+                    WHEN 'index' THEN 1
+                    WHEN 'view' THEN 2
+                    WHEN 'trigger' THEN 3
+                    ELSE 4
+                END,
+                name,
+                `sql`
+            SQL_WRAP;
+        $rows = $this->query->execute($sql);
+        $statements = array_map(fn (array $row): string => $this->normalizeStatement((string) $row['sql']), $rows);
+        $dump = trim(implode("\n", $statements));
+
+        return new State($dump);
+    }
+
+    /**
+     * Normalizes a statement by trimming and appending a semicolon if needed.
+     *
+     * @param string $statement Statement to normalize
+     *
+     * @return string Normalized statement
+     */
+    private function normalizeStatement(string $statement): string
+    {
+        $normalizedStatement = trim($statement);
+        if (!str_ends_with($normalizedStatement, ';')) {
+            $normalizedStatement .= ';';
+        }
+
+        return $normalizedStatement;
+    }
+}

--- a/tests/Db/Db/SqLiteDumperTest.php
+++ b/tests/Db/Db/SqLiteDumperTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Db\Db;
+
+use Codeception\Test\Unit;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Roslov\MigrationChecker\Db\SqLiteDumper;
+use Roslov\MigrationChecker\Db\SqlQuery;
+use Roslov\MigrationChecker\Tests\Support\DbTester;
+
+/**
+ * Tests the SQLite dump fetcher.
+ */
+#[CoversClass(SqLiteDumper::class)]
+final class SqLiteDumperTest extends Unit
+{
+    /**
+     * @var DbTester Tester
+     */
+    protected DbTester $tester;
+
+    /**
+     * Tests database dumps.
+     */
+    public function testGetDump(): void
+    {
+        $I = $this->tester;
+
+        $imageType = 'sqlite';
+        $query = new SqlQuery(
+            $I->getDsn($imageType),
+            $I->getUsername($imageType),
+            $I->getPassword(),
+        );
+        $dumper = new SqLiteDumper($query);
+        foreach ($this->getMigrations() as $migration) {
+            codecept_debug($migration);
+            $query->execute($migration);
+        }
+
+        self::assertSame(
+            $this->normalizeDump($this->getExpectedDump()),
+            $this->normalizeDump($dumper->getDump()->toString()),
+        );
+    }
+
+    /**
+     * Returns migration SQL for testing.
+     *
+     * @return string[] Migration SQLs
+     */
+    private function getMigrations(): array
+    {
+        return [
+            <<<'SQL_WRAP'
+                PRAGMA foreign_keys = ON
+                SQL_WRAP,
+            <<<'SQL_WRAP'
+                CREATE TABLE owner (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    first_name TEXT NOT NULL,
+                    last_name TEXT NOT NULL,
+                    code TEXT NOT NULL
+                )
+                SQL_WRAP,
+            <<<'SQL_WRAP'
+                CREATE UNIQUE INDEX idx_owner_name ON owner(first_name, last_name)
+                SQL_WRAP,
+            <<<'SQL_WRAP'
+                CREATE TABLE info (id INTEGER PRIMARY KEY, name TEXT NOT NULL)
+                SQL_WRAP,
+            <<<'SQL_WRAP'
+                CREATE TABLE pet (
+                    id INTEGER PRIMARY KEY,
+                    type TEXT NOT NULL,
+                    owner_id INTEGER NOT NULL,
+                    info_id INTEGER NOT NULL,
+                    CONSTRAINT fk_owner FOREIGN KEY(owner_id) REFERENCES owner(id)
+                        ON DELETE CASCADE ON UPDATE CASCADE,
+                    CONSTRAINT fk_info FOREIGN KEY(info_id) REFERENCES info(id)
+                        ON DELETE CASCADE ON UPDATE CASCADE
+                )
+                SQL_WRAP,
+            <<<'SQL_WRAP'
+                CREATE TABLE pet_tag (pet_id INTEGER NOT NULL, tag TEXT NOT NULL, PRIMARY KEY (pet_id, tag))
+                    WITHOUT ROWID
+                SQL_WRAP,
+            <<<'SQL_WRAP'
+                CREATE INDEX idx_pet_type ON pet(type) WHERE type IS NOT NULL
+                SQL_WRAP,
+            <<<'SQL_WRAP'
+                CREATE VIEW vw_pet AS SELECT id, type FROM pet
+                SQL_WRAP,
+            <<<'SQL_WRAP'
+                CREATE TRIGGER before_owner_update
+                BEFORE UPDATE ON owner
+                BEGIN
+                    UPDATE owner SET last_name = 'Doe' WHERE id = NEW.id AND NEW.first_name = 'John';
+                END
+                SQL_WRAP,
+        ];
+    }
+
+    /**
+     * Returns expected dump SQL for testing.
+     *
+     * @return string Expected dump SQL
+     */
+    private function getExpectedDump(): string
+    {
+        return (string) file_get_contents(codecept_data_dir('sqlite.dump.expected.sql'));
+    }
+
+    /**
+     * Normalizes dump strings for comparison.
+     *
+     * @param string $dump Dump to normalize
+     *
+     * @return string Normalized dump
+     */
+    private function normalizeDump(string $dump): string
+    {
+        $normalizedDump = preg_replace('/\s+/', ' ', $dump);
+
+        return trim((string) $normalizedDump);
+    }
+}

--- a/tests/Db/MigrationCheckerTest.php
+++ b/tests/Db/MigrationCheckerTest.php
@@ -87,7 +87,7 @@ final class MigrationCheckerTest extends Unit
             ['mysql', '8.4.5'],
             ['mariadb', '10.11.15'],
             ['postgresql', '17.7-alpine'],
-//            ['sqlite', ''],
+            ['sqlite', ''],
 //            ['sqlserver', '2022-CU21-ubuntu-22.04'],
 //            ['oracle', '21.3.0-slim'],
         ];

--- a/tests/Support/Data/sqlite.dump.expected.sql
+++ b/tests/Support/Data/sqlite.dump.expected.sql
@@ -1,0 +1,23 @@
+CREATE TABLE info (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+CREATE TABLE owner (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, first_name TEXT NOT NULL, last_name TEXT NOT NULL, code TEXT NOT NULL
+);
+CREATE TABLE pet (
+    id INTEGER PRIMARY KEY,
+    type TEXT NOT NULL,
+    owner_id INTEGER NOT NULL,
+    info_id INTEGER NOT NULL,
+    CONSTRAINT fk_owner FOREIGN KEY(owner_id) REFERENCES owner(id)
+        ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT fk_info FOREIGN KEY(info_id) REFERENCES info(id)
+        ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE TABLE pet_tag (pet_id INTEGER NOT NULL, tag TEXT NOT NULL, PRIMARY KEY (pet_id, tag)) WITHOUT ROWID;
+CREATE UNIQUE INDEX idx_owner_name ON owner(first_name, last_name);
+CREATE INDEX idx_pet_type ON pet(type) WHERE type IS NOT NULL;
+CREATE VIEW vw_pet AS SELECT id, type FROM pet;
+CREATE TRIGGER before_owner_update
+BEFORE UPDATE ON owner
+BEGIN
+    UPDATE owner SET last_name = 'Doe' WHERE id = NEW.id AND NEW.first_name = 'John';
+END;


### PR DESCRIPTION
### Motivation

- Add first-class support for SQLite schema dump extraction so the tool can detect and compare SQLite schemas.
- Ensure SQLite-specific features like `AUTOINCREMENT`, `WITHOUT ROWID`, partial indexes, views and triggers are captured and tested.

### Description

- Add `SqLiteDumper` implementation at `src/Db/SqLiteDumper.php` that queries `sqlite_master`, orders objects (tables, indexes, views, triggers) and normalizes statements (trim + ensure trailing semicolon). 
- Wire `DatabaseType::SqLite` into the dispatcher in `src/Db/Dumper.php` to return `new SqLiteDumper($this->query)`. 
- Add an integration-style test `tests/Db/Db/SqLiteDumperTest.php` which applies SQLite migrations exercising `AUTOINCREMENT`, `WITHOUT ROWID`, partial index, view and trigger features. 
- Add expected fixture data at `tests/Support/Data/sqlite.dump.expected.sql` and update `README.md` to document `SqLiteDumper` support.

### Testing

- Added automated test `tests/Db/Db/SqLiteDumperTest.php` and fixture `tests/Support/Data/sqlite.dump.expected.sql`